### PR TITLE
[Misc] Fix VerifyDepdendency

### DIFF
--- a/cycle.go
+++ b/cycle.go
@@ -115,6 +115,7 @@ func detectMissingDep(n provider, c containerStore, visited map[key]struct{}) er
 				return false
 			}
 		}
+		visited[k] = struct{}{}
 
 		return true
 	}


### PR DESCRIPTION
 as 593416ce0bda51009ac32cd67cf83785d6a363cb, miss to set visited, so will redundant traverse.